### PR TITLE
routes are pushed even when defaultGateway is true

### DIFF
--- a/config/config.php.example
+++ b/config/config.php.example
@@ -41,8 +41,7 @@ return [
             // DEFAULT = false
             'blockLan' => true,
 
-            // IPv4 and IPv6 routes to push to the client, only used when
-            // defaultGateway is false
+            // IPv4 and IPv6 routes to push to the client
             // DEFAULT = []
             'routes' => [
                 //'192.168.1.0/24',


### PR DESCRIPTION
The Office 365 on Windows hack requires a route to pushed in addition to the default gateway. The current configuration description suggests that this is not possible, but "routes" is still being used even if "defaultGateway" is set to true.

Therefore removing the statement that routes is only used when defaultGateway is false.